### PR TITLE
Update main.nim

### DIFF
--- a/compiler/front/main.nim
+++ b/compiler/front/main.nim
@@ -505,7 +505,7 @@ proc mainCommand*(graph: ModuleGraph) =
 
   ## command prepass
   if conf.cmd == cmdCrun: conf.incl {optRun, optUseNimcache}
-  if conf.cmd notin cmdBackends + {cmdTcc, cmdNimscript}:
+  if conf.cmd notin cmdBackends + {cmdTcc, cmdNimscript, cmdInteractive}:
     customizeForBackend(graph, conf, backendC)
   if conf.outDir.isEmpty:
     # doc like commands can generate a lot of files (especially with --project)
@@ -660,7 +660,9 @@ proc mainCommand*(graph: ModuleGraph) =
     wantMainModule(conf)
     commandView(graph)
     #msgWriteln(conf, "Beware: Indentation tokens depend on the parser's state!")
-  of cmdInteractive: commandInteractive(graph)
+  of cmdInteractive:
+    customizeForBackened(graph, conf, backendNimVm)
+    commandInteractive(graph)
   of cmdNimscript:
     if conf.inputMode == pimFile and not fileExists(conf.projectFull):
       localReport(conf, InternalReport(

--- a/tests/compiler/trepl.nim
+++ b/tests/compiler/trepl.nim
@@ -1,0 +1,5 @@
+********* Tests for REPL using nim secret ******************
+************************************************************
+import std/osproc
+
+let repl = exeCmd("nim secret")


### PR DESCRIPTION
When running `nim secret` the default compiler is backendC and should be backendVm.

## Summary
* what changed and how?
Added logic to compilation environment to disable ```backendC``` when calling ```nim secret``` and instead change to ```backendVm```
* why are we changing it? 

> Okay, the root of the problem is that the compilation environment is configured for as if the C backend were used. This leads to various semantic errors, and while that still shouldn't crash the compiler, it unfortunately does. Anyhow, since the REPL is effectively a backend itself, the customizeForBackend call at main.nim:510 needs to be disabled when the REPL is used (indicated bycmdInteractive).
commandInteractive (the procedure setting up the REPL) then needs to call customizeForBackend itself, but with backendVm rather than backendC.



## Details
* Credit goes to @zerbina:matrix.org

* relevant details; tricky parts
* anything else

Fixes full_issue_url

---
<!--- Anything before this section break (`---`) will be used as
the commit message when the PR is merged. -->

## Notes for Reviewers
* leave additional context for reviewers
* maybe specific requests or areas of focus

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
